### PR TITLE
Fix sometime failing test

### DIFF
--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -383,19 +383,11 @@ unmask_address(IP, Mask, Size) ->
             unmask_address(IP, Mask, Size - 1)
     end.
 
+
 %%%%%%%%%%%%%%%%
 %% Unit Tests %%
 %%%%%%%%%%%%%%%%
 
 -ifdef(TEST).
-
-lists_shuffle_test() ->
-    %% We can rely on the output to "expected" to be deterministic only as long
-    %% as lists_shuffle/1 uses a deterministic random function. It does for now.
-    In = lists:seq(0,9),
-    Expected = [4,0,8,3,5,9,7,1,2,6],
-    random:seed(),
-    Out = lists_shuffle(In),
-    ?assert(Expected == Out).
 
 -endif.

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -394,6 +394,7 @@ lists_shuffle_test() ->
     %% as lists_shuffle/1 uses a deterministic random function. It does for now.
     In = lists:seq(0,9),
     Expected = [4,0,8,3,5,9,7,1,2,6],
+    random:seed(),
     Out = lists_shuffle(In),
     ?assert(Expected == Out).
 


### PR DESCRIPTION
The test assumed that the shuffled order of the list would
be X because it assumed no other calls to random took place.
Maybe some recent changes added a call to `random`, but the
test fails on my ubuntu machine when `make eunit` is run.

This change calls `seed` in the test to ensure that "determinsitic random"
behaviour occurs for the test.